### PR TITLE
add empty method to gridlayout

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -13,6 +13,12 @@ function Base.foreach(f::Function, contenttype::Type, layout::GridLayout; recurs
     end
 end
 
+function Base.empty!(g::GridLayout)
+    foreach(delete!, Any, g)
+    foreach(remove_from_gridlayout!, g.content)
+    return g
+end
+
 """
 Swaps or rotates the layout positions of the given elements to their neighbor's.
 """


### PR DESCRIPTION
This implements what we were discussing on slack (call `delete!` on all the content and disconnect everything from the main layout). I wonder if we want:

1. Allow a `contenttype` argument (as second argument I guess) here as well, to allow only calling `delete!` on some types?
2. Also remove all columns and rows leaving a `GridLayout(1, 1)` at the end.