### PR TITLE
Soften precompile failures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GridLayoutBase"
 uuid = "3955a311-db13-416c-9275-1d80ed98e5e9"
 authors = ["Julius Krumbiegel"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"


### PR DESCRIPTION
I've taken the liberty to bump the version number because we should release ASAP to avoid test breakages on nightly. (Recent changes have cause one of these directives to fail.)