### PR TITLE
Replace FRect2D with Rect2f

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
-authors = ["Julius Krumbiegel"]
 name = "GridLayoutBase"
 uuid = "3955a311-db13-416c-9275-1d80ed98e5e9"
+authors = ["Julius Krumbiegel"]
 version = "0.5.7"
 
 [deps]
@@ -10,7 +10,7 @@ Match = "7eb4fadd-790c-5f42-8a69-bfa0b872bfbf"
 Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
 
 [compat]
-GeometryBasics = "0.2, 0.3"
+GeometryBasics = "0.4.1"
 Match = "^1"
 Observables = "0.3, 0.4"
 julia = "1"

--- a/src/geometry_integration.jl
+++ b/src/geometry_integration.jl
@@ -10,7 +10,7 @@ height(rect::Rect{2}) = top(rect) - bottom(rect)
 function BBox(left::Number, right::Number, bottom::Number, top::Number)
     mini = (left, bottom)
     maxi = (right, top)
-    return FRect2D(mini, maxi .- mini)
+    return Rect2f(mini, maxi .- mini)
 end
 
 
@@ -39,13 +39,13 @@ end
 """
 mapsides(
        f, first::Union{Rect{2}, RowCols}, rest::Union{Rect{2}, RowCols}...
-   )::FRect2D
+   )::Rect2f
 Maps f over all sides of the rectangle like arguments.
 e.g.
 ```
 mapsides(BBox(left, right, bottom, top)) do side::Side, side_val::Number
     return ...
-end::FRect2D
+end::Rect2f
 ```
 """
 function mapsides(

--- a/src/gridlayout.jl
+++ b/src/gridlayout.jl
@@ -615,7 +615,7 @@ into a given bounding box. This means that the protrusions of all objects inside
 the grid are not taken into account. This is needed if the grid is itself placed
 inside another grid.
 """
-function align_to_bbox!(gl::GridLayout, suggestedbbox::FRect2D)
+function align_to_bbox!(gl::GridLayout, suggestedbbox::Rect2f)
 
     # compute the actual bbox for the content given that there might be outside
     # padding that needs to be removed

--- a/src/layout_engine.jl
+++ b/src/layout_engine.jl
@@ -107,7 +107,7 @@ function protrusion(gl::GridLayout, side::Side)
     end
 end
 
-function bbox_for_solving_from_side(maxgrid::RowCols, bbox_cell::FRect2D, idx_rect::RowCols, side::Side)
+function bbox_for_solving_from_side(maxgrid::RowCols, bbox_cell::Rect2f, idx_rect::RowCols, side::Side)
     pl = maxgrid.lefts[idx_rect.lefts]
     pr = maxgrid.rights[idx_rect.rights]
     pt = maxgrid.tops[idx_rect.tops]

--- a/src/layoutobservables.jl
+++ b/src/layoutobservables.jl
@@ -74,12 +74,12 @@ end
 
 create_suggested_bboxobservable(n::Nothing) = Observable(BBox(0, 100, 0, 100))
 create_suggested_bboxobservable(tup::Tuple) = Observable(BBox(tup...))
-create_suggested_bboxobservable(bbox::Rect{2}) = Observable(FRect2D(bbox))
-create_suggested_bboxobservable(observable::Observable{FRect2D}) = observable
+create_suggested_bboxobservable(bbox::Rect{2}) = Observable(Rect2f(bbox))
+create_suggested_bboxobservable(observable::Observable{Rect2f}) = observable
 function create_suggested_bboxobservable(observable::Observable{<:Rect{2}})
-    bbox = Observable(FRect2D(observable[]))
+    bbox = Observable(Rect2f(observable[]))
     on(observable) do o
-        bbox[] = FRect2D(o)
+        bbox[] = Rect2f(o)
     end
     bbox
 end
@@ -186,7 +186,7 @@ end
 
 
 function alignedbboxobservable!(
-    suggestedbbox::Observable{FRect2D},
+    suggestedbbox::Observable{Rect2f},
     reportedsize::Observable{NTuple{2, Optional{Float32}}},
     alignment::Observable,
     sizeattrs::Observable,

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -19,16 +19,16 @@ function _precompile_()
 
     @warnpcfail precompile(GridLayout, (Int, Int))
     @warnpcfail precompile(GridLayout, (GridLayoutSpec,))
-    @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:bbox,), Tuple{Observable{IRect2D}}}, Type{GridLayout}))
-    @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:bbox,), Tuple{FRect2D}}, Type{GridLayout}))
+    @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:bbox,), Tuple{Observable{Rect2i}}}, Type{GridLayout}))
+    @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:bbox,), Tuple{Rect2f}}, Type{GridLayout}))
     # Also precompile `GridLayout(bbox = bbox, alignmode = al)` and the keyword body method
     fbody = isdefined(Base, :bodyfunction) ? Base.bodyfunction(which(GridLayout, (Int, Int))) : nothing
     for Al in (Inside, Outside, Mixed)
-        @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:bbox, :alignmode), Tuple{FRect2D, Al}}, Type{GridLayout}))
-        @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:bbox, :alignmode), Tuple{Observable{FRect2D}, Al}}, Type{GridLayout}))
+        @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:bbox, :alignmode), Tuple{Rect2f, Al}}, Type{GridLayout}))
+        @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:bbox, :alignmode), Tuple{Observable{Rect2f}, Al}}, Type{GridLayout}))
         @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:bbox, :alignmode), Tuple{NTuple{4,Int}, Al}}, Type{GridLayout}))
         if fbody !== nothing
-            @warnpcfail precompile(fbody, (Nothing, Nothing, Nothing, Nothing, Nothing, Al, Tuple{Bool, Bool}, FRect2D, Auto, Auto, Bool, Bool, Symbol, Symbol, Float64, Float64, Emptykwargs, Type{GridLayout}, Int, Int))
+            @warnpcfail precompile(fbody, (Nothing, Nothing, Nothing, Nothing, Nothing, Al, Tuple{Bool, Bool}, Rect2f, Auto, Auto, Bool, Bool, Symbol, Symbol, Float64, Float64, Emptykwargs, Type{GridLayout}, Int, Int))
         end
     end
     @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:colsizes, :rowsizes), Tuple{Fixed, Relative}}, Type{GridLayout}, Int, Int))
@@ -39,7 +39,7 @@ function _precompile_()
         @warnpcfail precompile(Outside, (T,))
         @warnpcfail precompile(Outside, (T,T,T,T))
     end
-    @warnpcfail precompile(align_to_bbox!, (GridLayout, FRect2D))
+    @warnpcfail precompile(align_to_bbox!, (GridLayout, Rect2f))
     @warnpcfail precompile(update!, (GridLayout,))
     for I in subtypes(Indexables), J in subtypes(Indexables)
         @warnpcfail precompile(setindex!, (GridLayout, UnitRange{Int}, I, J))
@@ -54,7 +54,7 @@ function _precompile_()
     @warnpcfail precompile(sizeobservable!, (Observable{Any}, Observable{Any}))
     @warnpcfail precompile(_reportedsizeobservable, (Tuple{SizeAttribute,SizeAttribute}, Tuple{AutoSize,AutoSize}, AlignMode, RectSides{Float32}, Tuple{Bool,Bool}))
     for T in subtypes(Side)
-        @warnpcfail precompile(bbox_for_solving_from_side, (RowCols{Vector{Float64}}, FRect2D, RowCols{Int}, T))
+        @warnpcfail precompile(bbox_for_solving_from_side, (RowCols{Vector{Float64}}, Rect2f, RowCols{Int}, T))
     end
     for S in (Left, Right, Top, Bottom)
         @warnpcfail precompile(protrusion, (GridContent{GridLayout,GridLayout}, S))

--- a/src/types.jl
+++ b/src/types.jl
@@ -140,19 +140,19 @@ end
 
 A collection of `Observable`s and an optional `GridContent` that are needed to interface with the MakieLayout layouting system.
 
-- `suggestedbbox::Observable{FRect2D}`: The bounding box that an element should place itself in. Depending on the element's `width` and `height` attributes, this is not necessarily equal to the computedbbox.
+- `suggestedbbox::Observable{Rect2f}`: The bounding box that an element should place itself in. Depending on the element's `width` and `height` attributes, this is not necessarily equal to the computedbbox.
 - `protrusions::Observable{RectSides{Float32}}`: The sizes of content "sticking out" of the main element into the `GridLayout` gaps.
 - `reportedsize::Observable{NTuple{2, Optional{Float32}}}`: The width and height that the element computes for itself if possible (else `nothing`).
 - `autosize::Observable{NTuple{2, Optional{Float32}}}`: The width and height that the element reports to its parent `GridLayout`. If the element doesn't want to cause the parent to adjust to its size, autosize can hide the reportedsize from it by being set to `nothing`.
-- `computedbbox::Observable{FRect2D}`: The bounding box that the element computes for itself after it has received a suggestedbbox.
+- `computedbbox::Observable{Rect2f}`: The bounding box that the element computes for itself after it has received a suggestedbbox.
 - `gridcontent::Optional{GridContent{G, T}}`: A reference of a `GridContent` if the element is currently placed in a `GridLayout`. This can be used to retrieve the parent layout, remove the element from it or change its position, and assign it to a different layout.
 """
 mutable struct LayoutObservables{T, G} # G again GridLayout
-    suggestedbbox::Observable{FRect2D}
+    suggestedbbox::Observable{Rect2f}
     protrusions::Observable{RectSides{Float32}}
     reportedsize::Observable{NTuple{2, Optional{Float32}}}
     autosize::Observable{NTuple{2, Optional{Float32}}}
-    computedbbox::Observable{FRect2D}
+    computedbbox::Observable{Rect2f}
     gridcontent::Optional{GridContent{G, T}} # the connecting link to the gridlayout
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -670,7 +670,7 @@ end
 
 @testset "integer rect2 suggestedbbox" begin
     layout = GridLayout(bbox = Observable(GridLayoutBase.GeometryBasics.Rect(0, 10, 20, 30)))
-    @test suggestedbboxobservable(layout)[] == GridLayoutBase.GeometryBasics.FRect2D(0, 10, 20, 30)
+    @test suggestedbboxobservable(layout)[] == GridLayoutBase.GeometryBasics.Rect2f(0, 10, 20, 30)
 end
 
 @testset "GridSubpositions" begin


### PR DESCRIPTION
This switches to new GeometryBasics type names from JuliaGeometry/GeometryBasics.jl#97.