### PR TITLE
More latency/inferrability work

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
 [compat]
 GeometryBasics = "0.4.1"
 Match = "^1"
-Observables = "0.3, 0.4"
+Observables = "0.4"
 julia = "1"
 
 [extras]

--- a/src/GridLayoutBase.jl
+++ b/src/GridLayoutBase.jl
@@ -1,11 +1,15 @@
 module GridLayoutBase
 
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@compiler_options"))
+    @eval Base.Experimental.@compiler_options compile=min optimize=1
+end
+
 using GeometryBasics
 using Observables
 using Match
 
-const DEFAULT_COLGAP = Ref{Any}(20.0)
-const DEFAULT_ROWGAP = Ref{Any}(20.0)
+const DEFAULT_COLGAP = Ref{Float64}(20.0)
+const DEFAULT_ROWGAP = Ref{Float64}(20.0)
 # These function refs can be mutated by other packages to override the default
 # way of retrieving default column and row gap sizes
 const DEFAULT_ROWGAP_GETTER = Ref{Function}(() -> DEFAULT_ROWGAP[])

--- a/src/GridLayoutBase.jl
+++ b/src/GridLayoutBase.jl
@@ -43,9 +43,8 @@ export protrusionsobservable, suggestedbboxobservable, reportedsizeobservable, a
 export ncols, nrows
 export contents, content
 
-# if Base.VERSION >= v"1.4.2"
-#     include("precompile.jl")
-#     _precompile_()
-# end
+if Base.VERSION >= v"1.4.2" && ccall(:jl_generating_output, Cint, ()) == 1
+    include("precompile.jl")
+end
 
 end

--- a/src/GridLayoutBase.jl
+++ b/src/GridLayoutBase.jl
@@ -39,9 +39,9 @@ export protrusionsobservable, suggestedbboxobservable, reportedsizeobservable, a
 export ncols, nrows
 export contents, content
 
-if Base.VERSION >= v"1.4.2"
-    include("precompile.jl")
-    _precompile_()
-end
+# if Base.VERSION >= v"1.4.2"
+#     include("precompile.jl")
+#     _precompile_()
+# end
 
 end

--- a/src/geometry_integration.jl
+++ b/src/geometry_integration.jl
@@ -7,12 +7,13 @@ width(rect::Rect{2}) = right(rect) - left(rect)
 height(rect::Rect{2}) = top(rect) - bottom(rect)
 
 
-function BBox(left::Number, right::Number, bottom::Number, top::Number)
+function BBox(left::Float32, right::Float32, bottom::Float32, top::Float32)
     mini = (left, bottom)
     maxi = (right, top)
     return Rect2f(mini, maxi .- mini)
 end
-
+BBox(left::Number, right::Number, bottom::Number, top::Number) =
+    BBox(Float32(left)::Float32, Float32(right)::Float32, Float32(bottom)::Float32, Float32(top)::Float32)
 
 function RowCols(ncols::Int, nrows::Int)
     return RowCols(
@@ -23,17 +24,17 @@ function RowCols(ncols::Int, nrows::Int)
     )
 end
 
-Base.getindex(rowcols::RowCols, ::Left) = rowcols.lefts
-Base.getindex(rowcols::RowCols, ::Right) = rowcols.rights
-Base.getindex(rowcols::RowCols, ::Top) = rowcols.tops
-Base.getindex(rowcols::RowCols, ::Bottom) = rowcols.bottoms
+Base.getindex(rowcols::RowCols, side::Side) = side == Left ? rowcols.lefts :
+                                              side == Right ? rowcols.rights :
+                                              side == Top ? rowcols.tops :
+                                              side == Bottom ? rowcols.bottoms : throw_side(side)
 
 """
     eachside(f)
 Calls f over all sides (Left, Right, Top, Bottom), and creates a BBox from the result of f(side)
 """
 function eachside(f)
-    return BBox(f(Left()), f(Right()), f(Bottom()), f(Top()))
+    return BBox(f(Left), f(Right), f(Bottom), f(Top))
 end
 
 """

--- a/src/gridlayoutspec.jl
+++ b/src/gridlayoutspec.jl
@@ -12,8 +12,8 @@ function GridLayout(spec::GridLayoutSpec)
 end
 
 const PosTuple = Tuple{Indexables, Indexables, Side}
-to_valid_pos(pos::Tuple{Indexables, Indexables}) = (pos[1], pos[2], Inner())
-to_valid_pos(pos::Tuple{Indexables, Indexables, Side}) = pos
+to_valid_pos(pos::Tuple{Indexables, Indexables}) = (pos[1], pos[2], Inner)
+to_valid_pos(pos::PosTuple) = pos
 
 function GridLayoutSpec(content::Vector{<:Pair}; kwargs...)
     spec_content = Pair{PosTuple, Any}[Pair{PosTuple, Any}(to_valid_pos(pos), c) for (pos, c) in content]

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,73 +1,14 @@
-using InteractiveUtils
-
-const Emptykwargs = Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}
-
-macro warnpcfail(ex::Expr)
-    modl = __module__
-    file = __source__.file === nothing ? "?" : String(__source__.file)
-    line = __source__.line
-    quote
-        $(esc(ex)) || @warn """precompile directive
-     $($(Expr(:quote, ex)))
- failed. Please report an issue in $($modl) (after checking for duplicates) or remove this directive.""" _file=$file _line=$line
+let
+    while true
+        bbox = BBox(0, 1000, 0, 1000)
+        layout = GridLayout(bbox = bbox, alignmode = Outside(0))
+        layout2 = GridLayout(1, 1)
+        layout[1, 1] = layout2
+        align_to_bbox!(layout, bbox)
+        compute_col_row_sizes(1.0, 1.0, layout)
+        determinedirsize(layout, Row)
+        trim!(layout)
+        break
     end
-end
-
-function _precompile_()
-    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    @warnpcfail precompile(BBox, (Float32, Float32, Float64, Float64))
-
-    @warnpcfail precompile(GridLayout, (Int, Int))
-    @warnpcfail precompile(GridLayout, (GridLayoutSpec,))
-    @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:bbox,), Tuple{Observable{Rect2i}}}, Type{GridLayout}))
-    @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:bbox,), Tuple{Rect2f}}, Type{GridLayout}))
-    # Also precompile `GridLayout(bbox = bbox, alignmode = al)` and the keyword body method
-    fbody = isdefined(Base, :bodyfunction) ? Base.bodyfunction(which(GridLayout, (Int, Int))) : nothing
-    for Al in (Inside, Outside, Mixed)
-        @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:bbox, :alignmode), Tuple{Rect2f, Al}}, Type{GridLayout}))
-        @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:bbox, :alignmode), Tuple{Observable{Rect2f}, Al}}, Type{GridLayout}))
-        @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:bbox, :alignmode), Tuple{NTuple{4,Int}, Al}}, Type{GridLayout}))
-        if fbody !== nothing
-            @warnpcfail precompile(fbody, (Nothing, Nothing, Nothing, Nothing, Nothing, Al, Tuple{Bool, Bool}, Rect2f, Auto, Auto, Bool, Bool, Symbol, Symbol, Float64, Float64, Emptykwargs, Type{GridLayout}, Int, Int))
-        end
-    end
-    @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:colsizes, :rowsizes), Tuple{Fixed, Relative}}, Type{GridLayout}, Int, Int))
-    @warnpcfail precompile(Core.kwfunc(GridLayout), (NamedTuple{(:addedcolgaps,), Tuple{Vector{Fixed}}}, Type{GridLayout}, Int, Int))
-
-    @warnpcfail precompile(Core.kwfunc(Mixed), (NamedTuple{(:left, :top), Tuple{Int, Int}}, Type{Mixed}))
-    for T in (Int, Float32)
-        @warnpcfail precompile(Outside, (T,))
-        @warnpcfail precompile(Outside, (T,T,T,T))
-    end
-    @warnpcfail precompile(align_to_bbox!, (GridLayout, Rect2f))
-    @warnpcfail precompile(update!, (GridLayout,))
-    for I in subtypes(Indexables), J in subtypes(Indexables)
-        @warnpcfail precompile(setindex!, (GridLayout, UnitRange{Int}, I, J))
-        @warnpcfail precompile(setindex!, (GridLayout, Any, I, J))
-    end
-    @warnpcfail precompile(insertrows!, (GridLayout, Int, Int))
-    @warnpcfail precompile(insertcols!, (GridLayout, Int, Int))
-    @warnpcfail precompile(gridnest!, (GridLayout, UnitRange{Int}, UnitRange{Int}))
-    @warnpcfail precompile(add_to_gridlayout!, (GridLayout, GridContent{GridLayout, GridLayout}))
-    @warnpcfail precompile(connect_layoutobservables!, (GridContent{GridLayout, GridLayout},))
-    @warnpcfail precompile(trim!, (GridLayout,))
-    @warnpcfail precompile(sizeobservable!, (Observable{Any}, Observable{Any}))
-    @warnpcfail precompile(_reportedsizeobservable, (Tuple{SizeAttribute,SizeAttribute}, Tuple{AutoSize,AutoSize}, AlignMode, RectSides{Float32}, Tuple{Bool,Bool}))
-    for T in subtypes(Side)
-        @warnpcfail precompile(bbox_for_solving_from_side, (RowCols{Vector{Float64}}, Rect2f, RowCols{Int}, T))
-    end
-    for S in (Left, Right, Top, Bottom)
-        @warnpcfail precompile(protrusion, (GridContent{GridLayout,GridLayout}, S))
-    end
-    @warnpcfail precompile(suggestedbboxobservable, (GridLayout,))
-    for VC in (Vector{Auto}, Vector{GapSize}, Vector{Fixed}, Vector{Relative}, Vector{ContentSize})
-        @warnpcfail precompile(convert_contentsizes, (Int, VC))
-        @warnpcfail precompile(==, (VC, VC))
-    end
-    @warnpcfail precompile(contents, (GridLayout,))
-    @warnpcfail precompile(filterenum, (Function, Type, Vector{ContentSize}))
-    @warnpcfail precompile(zcumsum, (Vector{Float64},))
-
-    # These don't work completely but they have partial success
-    @warnpcfail precompile(repr, (MIME{Symbol("text/plain")}, GridLayout))
+    nothing
 end

--- a/test/debugrect.jl
+++ b/test/debugrect.jl
@@ -1,21 +1,19 @@
 mutable struct DebugRect
-    layoutobservables::GridLayoutBase.LayoutObservables
-    width::Observable
-    height::Observable
-    tellwidth::Observable
-    tellheight::Observable
-    halign::Observable
-    valign::Observable
-    leftprot::Observable
-    rightprot::Observable
-    bottomprot::Observable
-    topprot::Observable
-    alignmode::Observable
+    layoutobservables::GridLayoutBase.LayoutObservables{GridLayout}
+    width::Observable{GridLayoutBase.SizeAttribute}
+    height::Observable{GridLayoutBase.SizeAttribute}
+    tellwidth::Observable{Bool}
+    tellheight::Observable{Bool}
+    halign::Observable{GridLayoutBase.AlignAttribute}
+    valign::Observable{GridLayoutBase.AlignAttribute}
+    leftprot::Observable{Float32}
+    rightprot::Observable{Float32}
+    bottomprot::Observable{Float32}
+    topprot::Observable{Float32}
+    alignmode::Observable{GridLayoutBase.AlignMode}
 end
 
-
-observablify(x::Observable) = x
-observablify(x, type=Any) = Observable{type}(x)
+using GridLayoutBase: observablify, Observablify
 
 function DebugRect(; bbox = nothing, width=nothing, height=nothing,
     tellwidth = true, tellheight = true, halign=:center,
@@ -28,17 +26,17 @@ function DebugRect(; bbox = nothing, width=nothing, height=nothing,
     tellheight = observablify(tellheight)
     halign = observablify(halign)
     valign = observablify(valign)
-    topprot = observablify(topprot, Float32)
-    leftprot = observablify(leftprot, Float32)
-    rightprot = observablify(rightprot, Float32)
-    bottomprot = observablify(bottomprot, Float32)
-    alignmode = observablify(alignmode)
+    topprot = Observablify{Float32}(topprot)
+    leftprot = Observablify{Float32}(leftprot)
+    rightprot = Observablify{Float32}(rightprot)
+    bottomprot = Observablify{Float32}(bottomprot)
+    alignmode = Observablify{GridLayoutBase.AlignMode}(alignmode)
 
     protrusions::Observable{GridLayoutBase.RectSides{Float32}} = map(leftprot, rightprot, bottomprot, topprot) do l, r, b, t
         GridLayoutBase.RectSides{Float32}(l, r, b, t)
     end
 
-    layoutobservables = GridLayoutBase.LayoutObservables{DebugRect}(width,
+    layoutobservables = GridLayoutBase.LayoutObservables{GridLayout}(width,
         height, tellwidth, tellheight, halign, valign, alignmode;
         suggestedbbox = bbox, protrusions = protrusions)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,27 +68,27 @@ end
     layout = GridLayout(bbox = bbox, alignmode = Mixed(left = 0, top = 100))
     dr = layout[1, 1] = DebugRect()
 
-    @test GridLayoutBase.protrusion(layout, Left()) == 0
-    @test GridLayoutBase.protrusion(layout, Right()) == 0
-    @test GridLayoutBase.protrusion(layout, Bottom()) == 0
-    @test GridLayoutBase.protrusion(layout, Top()) == 0
+    @test GridLayoutBase.protrusion(layout, Left) == 0
+    @test GridLayoutBase.protrusion(layout, Right) == 0
+    @test GridLayoutBase.protrusion(layout, Bottom) == 0
+    @test GridLayoutBase.protrusion(layout, Top) == 0
 
     @test computedbboxobservable(dr)[] == BBox(0, 1000, 0, 900)
 
     dr.topprot[] = 100
-    @test GridLayoutBase.protrusion(layout, Top()) == 0
+    @test GridLayoutBase.protrusion(layout, Top) == 0
     @test computedbboxobservable(dr)[] == BBox(0, 1000, 0, 800)
 
     dr.bottomprot[] = 100
-    @test GridLayoutBase.protrusion(layout, Bottom()) == 100
+    @test GridLayoutBase.protrusion(layout, Bottom) == 100
     @test computedbboxobservable(dr)[] == BBox(0, 1000, 0, 800)
 
     dr.leftprot[] = 100
-    @test GridLayoutBase.protrusion(layout, Left()) == 0
+    @test GridLayoutBase.protrusion(layout, Left) == 0
     @test computedbboxobservable(dr)[] == BBox(100, 1000, 0, 800)
 
     dr.rightprot[] = 100
-    @test GridLayoutBase.protrusion(layout, Right()) == 100
+    @test GridLayoutBase.protrusion(layout, Right) == 100
     @test computedbboxobservable(dr)[] == BBox(100, 1000, 0, 800)
 
     layout.alignmode[] = Mixed(
@@ -99,10 +99,10 @@ end
     )
 
     # set layout to forced protrusion alignment
-    @test GridLayoutBase.protrusion(layout, Left()) == 50
-    @test GridLayoutBase.protrusion(layout, Right()) == 60
-    @test GridLayoutBase.protrusion(layout, Bottom()) == 70
-    @test GridLayoutBase.protrusion(layout, Top()) == 80
+    @test GridLayoutBase.protrusion(layout, Left) == 50
+    @test GridLayoutBase.protrusion(layout, Right) == 60
+    @test GridLayoutBase.protrusion(layout, Bottom) == 70
+    @test GridLayoutBase.protrusion(layout, Top) == 80
     # bb of dr only depends on its protrusions now
     @test computedbboxobservable(dr)[] == BBox(100, 1000, 0, 800)
 
@@ -134,35 +134,35 @@ end
     layout = GridLayout(bbox = bbox, alignmode = Outside(0))
     subgl = layout[1, 1] = GridLayout()
 
-    subgl[1, 1, Left()] = DebugRect(width = Fixed(100))
-    @test GridLayoutBase.protrusion(subgl, Left()) == 100
+    subgl[1, 1, Left] = DebugRect(width = Fixed(100))
+    @test GridLayoutBase.protrusion(subgl, Left) == 100
 
-    subgl[1, 1, Top()] = DebugRect(height = 50)
-    @test GridLayoutBase.protrusion(subgl, Top()) == 50
+    subgl[1, 1, Top] = DebugRect(height = 50)
+    @test GridLayoutBase.protrusion(subgl, Top) == 50
 
-    subgl[1, 1, Right()] = DebugRect(width = 120)
-    @test GridLayoutBase.protrusion(subgl, Right()) == 120
+    subgl[1, 1, Right] = DebugRect(width = 120)
+    @test GridLayoutBase.protrusion(subgl, Right) == 120
 
-    subgl[1, 1, Bottom()] = DebugRect(height = 40)
-    @test GridLayoutBase.protrusion(subgl, Bottom()) == 40
+    subgl[1, 1, Bottom] = DebugRect(height = 40)
+    @test GridLayoutBase.protrusion(subgl, Bottom) == 40
 
-    subgl[1, 1, TopLeft()] = DebugRect(width = 200, height = 200)
-    @test GridLayoutBase.protrusion(subgl, Left()) == 200
-    @test GridLayoutBase.protrusion(subgl, Top()) == 200
+    subgl[1, 1, TopLeft] = DebugRect(width = 200, height = 200)
+    @test GridLayoutBase.protrusion(subgl, Left) == 200
+    @test GridLayoutBase.protrusion(subgl, Top) == 200
 
-    subgl[1, 1, TopRight()] = DebugRect(width = 210, height = 210)
-    @test GridLayoutBase.protrusion(subgl, Right()) == 210
-    @test GridLayoutBase.protrusion(subgl, Top()) == 210
+    subgl[1, 1, TopRight] = DebugRect(width = 210, height = 210)
+    @test GridLayoutBase.protrusion(subgl, Right) == 210
+    @test GridLayoutBase.protrusion(subgl, Top) == 210
 
-    subgl[1, 1, BottomRight()] = DebugRect(width = 220, height = 220)
-    @test GridLayoutBase.protrusion(subgl, Right()) == 220
-    @test GridLayoutBase.protrusion(subgl, Bottom()) == 220
+    subgl[1, 1, BottomRight] = DebugRect(width = 220, height = 220)
+    @test GridLayoutBase.protrusion(subgl, Right) == 220
+    @test GridLayoutBase.protrusion(subgl, Bottom) == 220
 
-    subgl[1, 1, BottomLeft()] = DebugRect(width = 230, height = 230)
-    @test GridLayoutBase.protrusion(subgl, Left()) == 230
-    @test GridLayoutBase.protrusion(subgl, Bottom()) == 230
+    subgl[1, 1, BottomLeft] = DebugRect(width = 230, height = 230)
+    @test GridLayoutBase.protrusion(subgl, Left) == 230
+    @test GridLayoutBase.protrusion(subgl, Bottom) == 230
 
-    # dr = subgl[1, 1, GridLayoutBase.Outer()] = DebugRect()
+    # dr = subgl[1, 1, GridLayoutBase.Outer] = DebugRect()
     # @test computedbboxobservable(dr)[].widths == (1000, 1000)
 end
 
@@ -473,7 +473,7 @@ end
     layout = GridLayout(bbox = bbox, alignmode = Outside(0))
     subgl = layout[1, 1] = GridLayout(3, 3, equalprotrusiongaps = (true, true),
         addedcolgaps = Fixed(0), addedrowgaps = Fixed(0))
-    subgl[1, 1, BottomRight()] = DebugRect(width = 100, height = 100)
+    subgl[1, 1, BottomRight] = DebugRect(width = 100, height = 100)
 
     dr1 = subgl[1, 1] = DebugRect()
     dr2 = subgl[2, 2] = DebugRect()
@@ -519,12 +519,12 @@ end
     co = contents(layout[:, :])
     @test co == [dr1, dr2, dr3, dr4]
 
-    dr5 = layout[2, 2, Right()] = DebugRect()
+    dr5 = layout[2, 2, Right] = DebugRect()
 
-    co = contents(layout[:, :]) # implicit Inner() side
+    co = contents(layout[:, :]) # implicit Inner side
     @test co == [dr1, dr2, dr3, dr4]
 
-    @test contents(layout[2, 2, Right()]) == [dr5]
+    @test contents(layout[2, 2, Right]) == [dr5]
 
     dr6 = layout[1:2, 2] = DebugRect()
     @test contents(layout[1:2, 2]) == [dr2, dr4, dr6]
@@ -551,26 +551,26 @@ end
     gl = GridLayout(;alignmode = Outside(0))
     gl[1, 1] = DebugRect(width = 800, height = 600)
 
-    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Row()) == 600
-    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Col()) == 800
+    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Row) == 600
+    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Col) == 800
 
-    gl[1, 1, Left()] = DebugRect(width = 200)
-    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Col()) == 800 + 200
-    gl[1, 1, Right()] = DebugRect(width = 200)
-    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Col()) == 800 + 200 + 200
+    gl[1, 1, Left] = DebugRect(width = 200)
+    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Col) == 800 + 200
+    gl[1, 1, Right] = DebugRect(width = 200)
+    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Col) == 800 + 200 + 200
 
-    gl[1, 1, Top()] = DebugRect(height = 100)
-    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Row()) == 600 + 100
-    gl[1, 1, Bottom()] = DebugRect(height = 100)
-    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Row()) == 600 + 100 + 100
+    gl[1, 1, Top] = DebugRect(height = 100)
+    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Row) == 600 + 100
+    gl[1, 1, Bottom] = DebugRect(height = 100)
+    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Row) == 600 + 100 + 100
 
     gl.alignmode[] = Outside(50)
-    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Col()) == 800 + 200 + 200 + 2 * 50
-    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Row()) == 600 + 100 + 100 + 2 * 50
+    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Col) == 800 + 200 + 200 + 2 * 50
+    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Row) == 600 + 100 + 100 + 2 * 50
 
     gl.alignmode[] = Inside()
-    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Col()) == 800
-    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Row()) == 600
+    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Col) == 800
+    @test GridLayoutBase.determinedirsize(gl, GridLayoutBase.Row) == 600
 end
 
 @testset "alignment" begin
@@ -625,7 +625,7 @@ end
 
     spec = GridLayoutSpec([
             (1, 1) => dr,
-            (1:2, 4:5, Left()) => dr2,
+            (1:2, 4:5, Left) => dr2,
             (:, 0) => GridLayoutSpec([
                 (1:3, 2:4) => dr3
             ])


### PR DESCRIPTION
This is a fairly extensive/intrusive change aimed at further reducing GridLayoutBase's contribution to the overall Makie latency. It shaves about 15% off the time to run the test suite.

The biggest changes are to the types:
- it makes `Side` and `GridDir` enums rather than types, to reduce the amount of compiler specialization
- it improves inferrability of GridLayout by changing the type-parameters (I hope I did this correctly, not sure)
- it switches to the Observables 0.4 style of doing business, and makes many Observables more inferrable

It also changes how the precompile file works. It may be slightly less comprehensive but far more portable.

You'll have to decide whether you think this is worthwhile, and if so on what schedule to adopt it.

As is presumably obvious, this is a breaking change.