### PR TITLE
Fix errors with Julia 1.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.3'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GridLayoutBase"
 uuid = "3955a311-db13-416c-9275-1d80ed98e5e9"
 authors = ["Julius Krumbiegel"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
@@ -13,7 +13,7 @@ Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
 GeometryBasics = "0.4.1"
 Match = "^1"
 Observables = "0.3, 0.4"
-julia = "1"
+julia = "1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/gridlayout.jl
+++ b/src/gridlayout.jl
@@ -1343,7 +1343,7 @@ function get_layout_at!(gp::GridPosition; createmissing = false)
             error("No layout found but `createmissing` is false.")
         end
     elseif length(layouts) == 1
-        return only(layouts)
+        return first(layouts)
     else
         error("Found more than zero or one GridLayouts at $gp")
     end


### PR DESCRIPTION
This PR fixes an error with Julia 1.3 (https://github.com/JuliaPlots/Makie.jl/pull/1244#issuecomment-903153774). I don't think there's any harm with using `first` instead of `only` since it is already ensured that this branch is only reached if the array contains only a single element. I also corrected the Julia lower bound to 1.3 since older versions are not supported (GeometryBasics 0.4.1 requires Julia 1.3). 