### PR TITLE
add effective protrusions to layoutobservables

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -150,6 +150,7 @@ A collection of `Observable`s and an optional `GridContent` that are needed to i
 struct LayoutObservables{G} # G again GridLayout
     suggestedbbox::Observable{Rect2f}
     protrusions::Observable{RectSides{Float32}}
+    effective_protrusions::Observable{RectSides{Float32}}
     reportedsize::Observable{NTuple{2, Optional{Float32}}}
     autosize::Observable{NTuple{2, Optional{Float32}}}
     computedbbox::Observable{Rect2f}


### PR DESCRIPTION
https://github.com/JuliaPlots/Makie.jl/pull/1796 showed that updating the alignmode after setting protrusions manually reset the actual protrusions in layoutobservables. As this is not desirable, now the "effective protrusions" are also stored in the layoutobservables. For example, with alignmode = Outside(), there are no protrusions for a given object, so the effective protrusions are all zero.