### PR TITLE
Fix aspect references

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GridLayoutBase"
 uuid = "3955a311-db13-416c-9275-1d80ed98e5e9"
 authors = ["Julius Krumbiegel"]
-version = "0.7.7"
+version = "0.7.8"
 
 [deps]
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"

--- a/src/gridlayout.jl
+++ b/src/gridlayout.jl
@@ -1190,14 +1190,14 @@ function compute_col_row_sizes(spaceforcolumns, spaceforrows, gl)::Tuple{Vector{
 
     # now aspect sizes that refer to already determined counterparts
     filterenum(Aspect, gl.colsizes) do (i, aspect)
-        aspectindex_unoffset = unoffset(gl, aspect.index, Col())
+        aspectindex_unoffset = unoffset(gl, aspect.index, Row())
         if determinedrows[aspectindex_unoffset]
             colwidths[i] = aspect.ratio * rowheights[aspectindex_unoffset]
             determinedcols[i] = true
         end
     end
     filterenum(Aspect, gl.rowsizes) do (i, aspect)
-        aspectindex_unoffset = unoffset(gl, aspect.index, Row())
+        aspectindex_unoffset = unoffset(gl, aspect.index, Col())
         if determinedcols[aspectindex_unoffset]
             rowheights[i] = aspect.ratio * colwidths[aspectindex_unoffset]
             determinedrows[i] = true
@@ -1262,7 +1262,7 @@ function compute_col_row_sizes(spaceforcolumns, spaceforrows, gl)::Tuple{Vector{
     # now if either columns or rows had no aspects left, they should have all sizes determined
     # we run over the aspects again
     filterenum(Aspect, gl.colsizes) do (i, aspect)
-        aspectindex_unoffset = unoffset(gl, aspect.index, Col())
+        aspectindex_unoffset = unoffset(gl, aspect.index, Row())
         if determinedrows[aspectindex_unoffset]
             colwidths[i] = aspect.ratio * rowheights[aspectindex_unoffset]
             determinedcols[i] = true
@@ -1271,7 +1271,7 @@ function compute_col_row_sizes(spaceforcolumns, spaceforrows, gl)::Tuple{Vector{
         end
     end
     filterenum(Aspect, gl.rowsizes) do (i, aspect)
-        aspectindex_unoffset = unoffset(gl, aspect.index, Row())
+        aspectindex_unoffset = unoffset(gl, aspect.index, Col())
         if determinedcols[aspectindex_unoffset]
             rowheights[i] = aspect.ratio * colwidths[aspectindex_unoffset]
             determinedrows[i] = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -883,6 +883,17 @@ end
     @test gridboxes.bottoms == [750, 0]
 end
 
+# issue 37
+@testset "Aspect indexing bug" begin
+    gl = GridLayout()
+    gl[0, 1] = DebugRect(height = 200)
+    @test_nowarn colsize!(gl, 1, Aspect(0, 1.0))
+
+    gl = GridLayout()
+    gl[1, 0] = DebugRect(width = 200)
+    @test_nowarn rowsize!(gl, 1, Aspect(0, 1.0))
+end
+
 @testset "colon rows/cols with offsets" begin
     gl = GridLayout()
     gl[0, 0] = GridLayout()


### PR DESCRIPTION
Fixes #37. The bug was that the indices in Aspect were 
offset with Row for rows, and Col for cols, while of course 
the dimensions that Aspect refers to are the 
opposite ones.
