### PR TITLE
add makie like gridlayout constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GridLayoutBase"
 uuid = "3955a311-db13-416c-9275-1d80ed98e5e9"
 authors = ["Julius Krumbiegel"]
-version = "0.7.8"
+version = "0.7.9"
 
 [deps]
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"

--- a/src/gridlayout.jl
+++ b/src/gridlayout.jl
@@ -1,4 +1,19 @@
+"""
+    GridLayout(; kwargs...)
+
+Create a `GridLayout` without parent and with size [1, 1].
+"""
 GridLayout(; kwargs...) = GridLayout(1, 1; kwargs...)
+
+"""
+    GridLayout(g::Union{GridPosition, GridSubposition}, args...; kwargs...)
+
+Create a `GridLayout` at position `g` in the parent `GridLayout` of `g` if it is a `GridPosition`
+and in a nested child `GridLayout` if it is a `GridSubposition`. The `args` and `kwargs` are passed on to the normal `GridLayout` constructor.
+"""
+function GridLayout(g::Union{GridPosition, GridSubposition}, args...; kwargs...)
+    return g[] = GridLayout(args...; kwargs...)
+end
 
 observablify(x::Observable) = x
 observablify(x, type=Any) = Observable{type}(x)
@@ -44,6 +59,28 @@ Base.convert(::Type{SizeAttribute}, a::Auto) = a
     end
 end
 
+"""
+    function GridLayout(nrows::Int, ncols::Int;
+        parent = nothing,
+        rowsizes = nothing,
+        colsizes = nothing,
+        addedrowgaps = nothing,
+        addedcolgaps = nothing,
+        alignmode = Inside(),
+        equalprotrusiongaps = (false, false),
+        bbox = nothing,
+        width = Auto(),
+        height = Auto(),
+        tellwidth::Bool = true,
+        tellheight::Bool = true,
+        halign = :center,
+        valign = :center,
+        default_rowgap = get_default_rowgap(),
+        default_colgap = get_default_colgap(),
+        kwargs...)
+
+Create a `GridLayout` with optional parent `parent` with `nrows` rows and `ncols` columns.
+"""
 function GridLayout(nrows::Int, ncols::Int;
         parent = nothing,
         rowsizes = nothing,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -952,3 +952,15 @@ end
     @test GridLayoutBase.protrusionsobservable(gl)[] == GridLayoutBase.RectSides{Float32}(0, 200, 0, 0)
     @test GridLayoutBase.effectiveprotrusionsobservable(gl)[] == GridLayoutBase.RectSides{Float32}(0, 200, 0, 0)
 end
+
+@testset "GridLayout GridPosition/GridSubposition constructor" begin
+    gl = GridLayout()
+    gl2 = GridLayout(gl[1, 1])
+    @test gl2.parent == gl
+    @test gl2.layoutobservables.gridcontent[].span == GridLayoutBase.Span(1:1, 1:1)
+    gl3 = GridLayout(gl[1, 2][1, 1])
+    @test gl3.parent != gl
+    @test gl3.parent == gl.content[2].content
+    @test gl3.layoutobservables.gridcontent[].span == GridLayoutBase.Span(1:1, 1:1)
+    @test gl.content[2].content.layoutobservables.gridcontent[].span == GridLayoutBase.Span(1:1, 2:2)
+end


### PR DESCRIPTION
In Makie, objects are created and placed into a `GridLayout` like `Axis(f[1, 1])` where `f[1, 1]` is a normal `GridPosition` from `GridLayoutBase`. But this didn't work with `GridLayout` itself, so this PR adds that behavior. Now an intermediate `GridLayout` would usually be done with `gl = GridLayout(f[1, 1])` not `gl = f[1, 1] = GridLayout()`.