### PR TITLE
remove unbound type parameter

### DIFF
--- a/src/layoutobservables.jl
+++ b/src/layoutobservables.jl
@@ -26,7 +26,7 @@ function LayoutObservables(width::Observable, height::Observable,
         suggestedbbox = nothing,
         protrusions = nothing,
         gridcontent = nothing,
-        block_updates::Bool = false) where T
+        block_updates::Bool = false)
 
     width_obs = convert(Observable{SizeAttribute}, width)
     height_obs = convert(Observable{SizeAttribute}, height)


### PR DESCRIPTION
Unbound type parameters often cause performance issues and run time dispatch.

Issue found using https://github.com/JuliaLang/julia/pull/46608