### PR TITLE
Generalize BBox attempt 2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
 
 [compat]
-GeometryBasics = "0.4.1"
+GeometryBasics = "0.4.11"
 Observables = "0.3, 0.4, 0.5"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GridLayoutBase"
 uuid = "3955a311-db13-416c-9275-1d80ed98e5e9"
 authors = ["Julius Krumbiegel"]
-version = "0.10.2"
+version = "0.11.0"
 
 [deps]
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -113,10 +113,15 @@ right(rect::Rect{2}) = maximum(rect)[1]
 bottom(rect::Rect{2}) = minimum(rect)[2]
 top(rect::Rect{2}) = maximum(rect)[2]
 
-function BBox(left::Number, right::Number, bottom::Number, top::Number)
+function BBox(left::T1, right::T2, bottom::T3, top::T4) where {T1 <: Real, T2 <: Real, T3 <: Real, T4 <: Real}
+    T = promote_type(T1, T2, T3, T4, Float32) # Float32 to skip Int outputs
+    return BBox(T, left, right, bottom, top)
+end
+
+function BBox(T::DataType, left::Real, right::Real, bottom::Real, top::Real)
     mini = (left, bottom)
     maxi = (right, top)
-    return Rect2f(mini, maxi .- mini)
+    return Rect2{T}(mini, maxi .- mini)
 end
 
 function RowCols(ncols::Integer, nrows::Integer)


### PR DESCRIPTION
Redo of #52 with breaking version

Also I noticed that `promote_type(Int64, Float32)` ends up with Float32. That might be a bit annoying for setting Axis limits in Makie.