### PR TITLE
Add @nospecialize to GridLayout(::Integer, ::Integer, ...)

### DIFF
--- a/src/gridlayout.jl
+++ b/src/gridlayout.jl
@@ -100,6 +100,7 @@ function GridLayout(nrows::Integer, ncols::Integer;
         default_rowgap = get_default_rowgap(),
         default_colgap = get_default_colgap(),
         kwargs...)
+    Base.@nospecialize
 
     default_rowgap::GapSize = default_rowgap isa Number ? Fixed(default_rowgap)::Fixed : default_rowgap
     default_colgap::GapSize = default_colgap isa Number ? Fixed(default_colgap)::Fixed : default_colgap


### PR DESCRIPTION
This prevents expensive compilation when called with bbox from Makie.

```
using SnoopCompileCore


@snoop_llvm "func_names.csv" "llvm_timings.yaml" begin
    using GLMakie
    GLMakie.activate!()
    function yy()
        fig = Figure()
        panel = fig[1, 1] = GridLayout()
        ax = Axis(panel[1, 1])
    end
    yy()
end
```

Without this I get:

```
 0.016817037 => ["Tuple{GridLayoutBase.var\"##GridLayout#10\", Nothing, Nothing, Nothing, Nothing, Nothing, GridLayoutBase.Inside, Tuple{Bool, Bool}, Nothing, GridLayoutBase.Auto, GridLayoutBase.Auto, Bool, Bool, Symbol, Symbol, Float64, Float64, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, Type{GridLayoutBase.GridLayout}, Int64, Int64}"]
```

The total amount of compilation time for `yy(..)` is quite high, about ~90% of 0.4s on my system. I'm not sure if there's some bigger easy win, but this is is the best I've been able to come up with after quite a while of trying to figure it out.