### PR TITLE
Prepare for Makie 0.22 / GeometryBasics 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GridLayoutBase"
 uuid = "3955a311-db13-416c-9275-1d80ed98e5e9"
 authors = ["Julius Krumbiegel"]
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
@@ -9,7 +9,7 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
 
 [compat]
-GeometryBasics = "0.4.11"
+GeometryBasics = "0.4.11, 0.5"
 Observables = "0.3, 0.4, 0.5"
 julia = "1.3"
 


### PR DESCRIPTION
If this only relies on Point, Vec and Rect2 this should be fine as a patch Version. If Rect3 is used we need to be a bit careful because `coordinates` changed (no duplication). 